### PR TITLE
chore(ci): don't do a release on certain changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - examples/**
+      - .github/ISSUE_TEMPLATE/**
+      - .github/CODEOWNERS
+      - .github/dependabot.yml
+      - .github/**/*.md
   workflow_dispatch: {}
 jobs:
   release:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -107,4 +107,19 @@ Object.entries(githubActionPinnedVersions).forEach(([action, sha]) => {
   project.github?.actions.set(action, `${action}@${sha}`);
 });
 
+const releaseWorkflow = project.tryFindObjectFile(
+  ".github/workflows/release.yml"
+);
+releaseWorkflow?.addOverride("on.push", {
+  branches: ["main"],
+  "paths-ignore": [
+    // don't do a release if the change was only to these files/directories
+    "examples/**",
+    ".github/ISSUE_TEMPLATE/**",
+    ".github/CODEOWNERS",
+    ".github/dependabot.yml",
+    ".github/**/*.md",
+  ],
+});
+
 project.synth();


### PR DESCRIPTION
If only a few specific directories are changed, no need to trigger a whole new release for that.