### PR TITLE
chore(deps)!: upgrade minimum required version of constructs to 10.3.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.25",
+      "version": "^10.3.0",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -28,7 +28,7 @@ const githubActionPinnedVersions = {
   "peter-evans/create-pull-request": "67ccf781d68cd99b580ae25a5c18a1cc84ffff1f", // v7.0.6
 };
 
-const constructsVersion = "10.0.25";
+const constructsVersion = "10.3.0";
 /** JSII and TS should always use the same major/minor version range */
 const typescriptVersion = "~5.5.0";
 const project = new ConstructLibraryCdktf({

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By using the software in this repository, you acknowledge that:
 ## Compatibility
 
 * `cdktf` >= 0.20.0
-* `constructs` >= 10.0.25
+* `constructs` >= 10.3.0
 
 ## Available Packages
 

--- a/docs/csharp.md
+++ b/docs/csharp.md
@@ -139,7 +139,7 @@ Adds this resource to the terraform JSON output.
 
 ---
 
-##### ~~`IsConstruct`~~ <a name="IsConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
+##### `IsConstruct` <a name="IsConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf.TfModuleStack;
@@ -148,6 +148,20 @@ ProviderRequirement.IsConstruct(object X);
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `X`<sup>Required</sup> <a name="X" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct.parameter.x"></a>
 
@@ -378,7 +392,7 @@ Synthesizes all resources to the output directory.
 
 ---
 
-##### ~~`IsConstruct`~~ <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
+##### `IsConstruct` <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf.TfModuleStack;
@@ -387,6 +401,20 @@ TFModuleApp.IsConstruct(object X);
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `X`<sup>Required</sup> <a name="X" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct.parameter.x"></a>
 
@@ -649,7 +677,7 @@ private object ToTerraform()
 
 ---
 
-##### ~~`IsConstruct`~~ <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
+##### `IsConstruct` <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf.TfModuleStack;
@@ -658,6 +686,20 @@ TFModuleOutput.IsConstruct(object X);
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `X`<sup>Required</sup> <a name="X" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct.parameter.x"></a>
 
@@ -1005,7 +1047,7 @@ private object ToTerraform()
 
 ---
 
-##### ~~`IsConstruct`~~ <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
+##### `IsConstruct` <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf.TfModuleStack;
@@ -1014,6 +1056,20 @@ TFModuleStack.IsConstruct(object X);
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `X`<sup>Required</sup> <a name="X" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct.parameter.x"></a>
 
@@ -1259,7 +1315,7 @@ private System.Collections.Generic.IDictionary<string, object> SynthesizeHclAttr
 
 ---
 
-##### ~~`IsConstruct`~~ <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
+##### `IsConstruct` <a name="IsConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf.TfModuleStack;
@@ -1268,6 +1324,20 @@ TFModuleVariable.IsConstruct(object X);
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `X`<sup>Required</sup> <a name="X" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct.parameter.x"></a>
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -139,7 +139,7 @@ Adds this resource to the terraform JSON output.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.tf_module_stack.ProviderRequirement;
@@ -148,6 +148,20 @@ ProviderRequirement.isConstruct(java.lang.Object x)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct.parameter.x"></a>
 
@@ -436,7 +450,7 @@ Synthesizes all resources to the output directory.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.tf_module_stack.TFModuleApp;
@@ -445,6 +459,20 @@ TFModuleApp.isConstruct(java.lang.Object x)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct.parameter.x"></a>
 
@@ -752,7 +780,7 @@ public java.lang.Object toTerraform()
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.tf_module_stack.TFModuleOutput;
@@ -761,6 +789,20 @@ TFModuleOutput.isConstruct(java.lang.Object x)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct.parameter.x"></a>
 
@@ -1108,7 +1150,7 @@ public java.lang.Object toTerraform()
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.tf_module_stack.TFModuleStack;
@@ -1117,6 +1159,20 @@ TFModuleStack.isConstruct(java.lang.Object x)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct.parameter.x"></a>
 
@@ -1430,7 +1486,7 @@ public java.util.Map<java.lang.String, java.lang.Object> synthesizeHclAttributes
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.tf_module_stack.TFModuleVariable;
@@ -1439,6 +1495,20 @@ TFModuleVariable.isConstruct(java.lang.Object x)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct.parameter.x"></a>
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -149,7 +149,7 @@ Adds this resource to the terraform JSON output.
 
 ---
 
-##### ~~`is_construct`~~ <a name="is_construct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
+##### `is_construct` <a name="is_construct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
 
 ```python
 import cdktf_tf_module_stack
@@ -160,6 +160,20 @@ cdktf_tf_module_stack.ProviderRequirement.is_construct(
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct.parameter.x"></a>
 
@@ -456,7 +470,7 @@ Synthesizes all resources to the output directory.
 
 ---
 
-##### ~~`is_construct`~~ <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
+##### `is_construct` <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
 
 ```python
 import cdktf_tf_module_stack
@@ -467,6 +481,20 @@ cdktf_tf_module_stack.TFModuleApp.is_construct(
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct.parameter.x"></a>
 
@@ -785,7 +813,7 @@ def to_terraform() -> typing.Any
 
 ---
 
-##### ~~`is_construct`~~ <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
+##### `is_construct` <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
 
 ```python
 import cdktf_tf_module_stack
@@ -796,6 +824,20 @@ cdktf_tf_module_stack.TFModuleOutput.is_construct(
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct.parameter.x"></a>
 
@@ -1163,7 +1205,7 @@ def to_terraform() -> typing.Any
 
 ---
 
-##### ~~`is_construct`~~ <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
+##### `is_construct` <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
 
 ```python
 import cdktf_tf_module_stack
@@ -1174,6 +1216,20 @@ cdktf_tf_module_stack.TFModuleStack.is_construct(
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct.parameter.x"></a>
 
@@ -1511,7 +1567,7 @@ def synthesize_hcl_attributes() -> typing.Mapping[typing.Any]
 
 ---
 
-##### ~~`is_construct`~~ <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
+##### `is_construct` <a name="is_construct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
 
 ```python
 import cdktf_tf_module_stack
@@ -1522,6 +1578,20 @@ cdktf_tf_module_stack.TFModuleVariable.is_construct(
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct.parameter.x"></a>
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -139,7 +139,7 @@ Adds this resource to the terraform JSON output.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct"></a>
 
 ```typescript
 import { ProviderRequirement } from '@cdktf/tf-module-stack'
@@ -148,6 +148,20 @@ ProviderRequirement.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.ProviderRequirement.isConstruct.parameter.x"></a>
 
@@ -378,7 +392,7 @@ Synthesizes all resources to the output directory.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct"></a>
 
 ```typescript
 import { TFModuleApp } from '@cdktf/tf-module-stack'
@@ -387,6 +401,20 @@ TFModuleApp.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleApp.isConstruct.parameter.x"></a>
 
@@ -649,7 +677,7 @@ public toTerraform(): any
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct"></a>
 
 ```typescript
 import { TFModuleOutput } from '@cdktf/tf-module-stack'
@@ -658,6 +686,20 @@ TFModuleOutput.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleOutput.isConstruct.parameter.x"></a>
 
@@ -1005,7 +1047,7 @@ public toTerraform(): any
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct"></a>
 
 ```typescript
 import { TFModuleStack } from '@cdktf/tf-module-stack'
@@ -1014,6 +1056,20 @@ TFModuleStack.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleStack.isConstruct.parameter.x"></a>
 
@@ -1259,7 +1315,7 @@ public synthesizeHclAttributes(): {[ key: string ]: any}
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct"></a>
 
 ```typescript
 import { TFModuleVariable } from '@cdktf/tf-module-stack'
@@ -1268,6 +1324,20 @@ TFModuleVariable.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="@cdktf/tf-module-stack.TFModuleVariable.isConstruct.parameter.x"></a>
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@typescript-eslint/parser": "^8",
     "cdktf": "0.20.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.0.25",
+    "constructs": "10.3.0",
     "eslint": "^9",
     "eslint-config-prettier": "^8.10.0",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "cdktf": ">=0.20.0",
-    "constructs": "^10.0.25"
+    "constructs": "^10.3.0"
   },
   "keywords": [
     "cdk",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,10 +1600,10 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-constructs@10.0.25:
-  version "10.0.25"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.25.tgz#c2f03fb4da134105fdf5382f4c1557b89d90aeeb"
-  integrity sha512-QxY4A7caIW1tI5ztbdZHKU/nWXiqluujmEVj5xCVhFhoBgOqU4ja3z3zXY4DUn2nf+PLxCjulf+viQ/h9RXB8A==
+constructs@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.3.0.tgz#4c246fce9cf8e77711ad45944e9fbd41f1501965"
+  integrity sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==
 
 constructs@^10.0.0:
   version "10.4.2"


### PR DESCRIPTION
Because `@cdktf/provider-null` and `@cdktf/provider-random` require a peerDependency of `constructs@^10.3.0`, we should upgrade.

For the future, scripts exist to better keep CDKTF and constructs packages in sync. For now, we'll just manually address this one-off instance of drift.